### PR TITLE
fix: vite optimizeDeps for visual editing + studio schema imports from @sanity/types

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -30,7 +30,21 @@ export default defineNuxtConfig({
   vite: {
     plugins: [tailwindcss()],
     optimizeDeps: {
-      include: ["shallowequal", "lodash/startCase.js"],
+      include: [
+        "lodash/startCase.js",
+        "@nuxtjs/sanity > @sanity/visual-editing > @sanity/insert-menu",
+        "@nuxtjs/sanity > @sanity/visual-editing > @sanity/mutate > lodash/groupBy.js",
+        "@nuxtjs/sanity > @sanity/visual-editing > @sanity/ui > styled-components",
+        "@nuxtjs/sanity > @sanity/visual-editing > @sanity/visual-editing > react-is",
+        "@nuxtjs/sanity > @sanity/visual-editing > react",
+        "@nuxtjs/sanity > @sanity/visual-editing > react/jsx-runtime",
+        "@nuxtjs/sanity > @sanity/visual-editing > react-dom",
+        "@nuxtjs/sanity > @sanity/visual-editing > react-dom/client",
+        "@nuxtjs/sanity > @sanity/visual-editing > react-compiler-runtime",
+        "@sanity/client",
+        "@nuxtjs/sanity > @sanity/client > @sanity/visual-editing",
+        "groq",
+      ],
     },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10098,7 +10098,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -24845,6 +24845,7 @@
       "dependencies": {
         "@sanity/assist": "^6.0.5",
         "@sanity/icons": "^3.7.4",
+        "@sanity/types": "^5.24.0",
         "@sanity/vision": "5.24.0",
         "pluralize-esm": "^9.0.5",
         "react": "^19.2.6",

--- a/studio/package.json
+++ b/studio/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@sanity/assist": "^6.0.5",
     "@sanity/icons": "^3.7.4",
+    "@sanity/types": "^5.24.0",
     "@sanity/vision": "5.24.0",
     "pluralize-esm": "^9.0.5",
     "react": "^19.2.6",

--- a/studio/src/schemaTypes/documents/page.ts
+++ b/studio/src/schemaTypes/documents/page.ts
@@ -1,4 +1,4 @@
-import {defineField, defineType} from 'sanity'
+import {defineField, defineType} from '@sanity/types'
 import {DocumentIcon} from '@sanity/icons'
 
 /**

--- a/studio/src/schemaTypes/documents/person.ts
+++ b/studio/src/schemaTypes/documents/person.ts
@@ -1,5 +1,5 @@
 import {UserIcon} from '@sanity/icons'
-import {defineField, defineType} from 'sanity'
+import {defineField, defineType} from '@sanity/types'
 
 /**
  * Person schema.  Define and edit the fields for the 'person' content type.

--- a/studio/src/schemaTypes/documents/post.ts
+++ b/studio/src/schemaTypes/documents/post.ts
@@ -1,5 +1,5 @@
 import {DocumentTextIcon} from '@sanity/icons'
-import {defineField, defineType} from 'sanity'
+import {defineField, defineType} from '@sanity/types'
 
 /**
  * Post schema.  Define and edit the fields for the 'post' content type.

--- a/studio/src/schemaTypes/objects/blockContent.tsx
+++ b/studio/src/schemaTypes/objects/blockContent.tsx
@@ -1,4 +1,4 @@
-import {defineArrayMember, defineType, defineField} from 'sanity'
+import {defineArrayMember, defineType, defineField} from '@sanity/types'
 
 /**
  * This is the schema definition for the rich text fields used for

--- a/studio/src/schemaTypes/objects/callToAction.ts
+++ b/studio/src/schemaTypes/objects/callToAction.ts
@@ -1,4 +1,4 @@
-import {defineField, defineType} from 'sanity'
+import {defineField, defineType} from '@sanity/types'
 import {BulbOutlineIcon} from '@sanity/icons'
 
 /**

--- a/studio/src/schemaTypes/objects/infoSection.ts
+++ b/studio/src/schemaTypes/objects/infoSection.ts
@@ -1,4 +1,4 @@
-import {defineField, defineType} from 'sanity'
+import {defineField, defineType} from '@sanity/types'
 import {TextIcon} from '@sanity/icons'
 
 export const infoSection = defineType({

--- a/studio/src/schemaTypes/objects/link.ts
+++ b/studio/src/schemaTypes/objects/link.ts
@@ -1,4 +1,4 @@
-import {defineField, defineType} from 'sanity'
+import {defineField, defineType} from '@sanity/types'
 import {LinkIcon} from '@sanity/icons'
 
 /**

--- a/studio/src/schemaTypes/singletons/settings.tsx
+++ b/studio/src/schemaTypes/singletons/settings.tsx
@@ -1,5 +1,5 @@
 import {CogIcon} from '@sanity/icons'
-import {defineArrayMember, defineField, defineType} from 'sanity'
+import {defineArrayMember, defineField, defineType} from '@sanity/types'
 
 import * as demo from '../../lib/initialValues'
 


### PR DESCRIPTION
## Summary
- Expand `vite.optimizeDeps.include` in `frontend/nuxt.config.ts` with the full set of `@nuxtjs/sanity`/visual-editing transitive deps so Vite pre-bundles them up front instead of triggering reloads in dev.
- Switch `defineField` / `defineType` / `defineArrayMember` imports across all 8 studio schema files from `'sanity'` to `'@sanity/types'`, and add `@sanity/types` as a direct studio dependency. Decouples the schema definitions from the full `sanity` Studio runtime — better for schema-extract/typegen contexts.

## Test plan
- [x] `npm install` from repo root resolves cleanly
- [x] `cd studio && npm run extract-types` succeeds with the new `@sanity/types` imports
- [x] `cd frontend && npm run dev` starts without the prior `@nuxtjs/sanity` pre-bundle reload warnings
- [x] Visual editing loads in the browser and works as expected